### PR TITLE
Declare global variables

### DIFF
--- a/vhdl-tools.el
+++ b/vhdl-tools.el
@@ -111,6 +111,15 @@ Needed to determine end of name."
 (defcustom vhdl-tools-imenu-regexp "^\\s-*--\\s-\\([*]\\{1,8\\}\\s-.+\\)"
   "Regexp ...")
 
+(defvar vhdl-tools-jump-into-module-name nil)
+(defvar vhdl-tools-store-link-link nil)
+(defvar vhdl-tools-store-link-link nil)
+(defvar vhdl-tools-outline-active nil)
+(defvar vhdl-tools-ggtags-active nil)
+(defvar vhdl-tools-outline-regexp-old nil)
+(defvar vhdl-tools-follow-links-tag nil)
+(defvar vhdl-tools-follow-links-tosearch nil)
+
 ;;; Helper
 
 (defun vhdl-tools-push-marker ()


### PR DESCRIPTION
Global variables should be declared for byte-compile warnings. There are many byte-compile warnings about this issue.

```
In vhdl-tools-jump-into-module:
vhdl-tools.el:348:42:Warning: assignment to free variable
    `vhdl-tools-jump-into-module-name'

In vhdl-tools-store-link:
vhdl-tools.el:442:11:Warning: assignment to free variable
    `vhdl-tools-store-link-link'

In vhdl-tools-paste-link:
vhdl-tools.el:450:26:Warning: reference to free variable
    `vhdl-tools-store-link-link'

In vhdl-tools-follow-links:
vhdl-tools.el:502:29:Warning: assignment to free variable
    `vhdl-tools-follow-links-tag'
vhdl-tools.el:485:9:Warning: assignment to free variable
    `vhdl-tools-follow-links-tosearch'
vhdl-tools.el:494:40:Warning: reference to free variable
    `vhdl-tools-follow-links-tosearch'
vhdl-tools.el:502:6:Warning: reference to free variable
    `vhdl-tools-follow-links-tag'
vhdl-tools.el:627:17:Warning: reference to free variable
    `vhdl-tools-imenu-map'

In vhdl-tools-mode:
vhdl-tools.el:661:18:Warning: assignment to free variable
    `vhdl-tools-outline-active'
vhdl-tools.el:663:18:Warning: assignment to free variable
    `vhdl-tools-ggtags-active'
vhdl-tools.el:656:21:Warning: assignment to free variable
    `vhdl-tools-outline-regexp-old'
vhdl-tools.el:658:10:Warning: reference to free variable
    `vhdl-tools-outline-active'
vhdl-tools.el:658:10:Warning: reference to free variable
    `vhdl-tools-ggtags-active'
vhdl-tools.el:658:10:Warning: reference to free variable
    `vhdl-tools-outline-regexp-old'
```
